### PR TITLE
:nail_care: We take care of type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,18 @@
   "packages": {
     "": {
       "dependencies": {
-        "@types/chalk": "^0.4.31",
-        "@types/node": "^22.9.3",
         "discord.js": "^14.16.3",
-        "dotenv": "^16.4.5",
-        "typescript": "^5.7.2"
+        "dotenv": "^16.4.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
+        "@types/chalk": "^0.4.31",
+        "@types/node": "^22.9.3",
         "@typescript-eslint/eslint-plugin": "^8.15.0",
         "@typescript-eslint/parser": "^8.15.0",
         "eslint": "^9.15.0",
         "globals": "^15.12.0",
+        "typescript": "^5.7.2",
         "typescript-eslint": "^8.15.0"
       }
     },
@@ -449,6 +449,7 @@
       "version": "0.4.31",
       "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
       "integrity": "sha512-nF0fisEPYMIyfrFgabFimsz9Lnuu9MwkNrrlATm2E4E46afKDyeelT+8bXfw1VSc7sLBxMxRgT7PxTC2JcqN4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -1809,6 +1810,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,7 +1,8 @@
 import { readdirSync } from "fs";
 import { REST, Routes } from "discord.js";
+import { Lilla } from "../../types/lilla";
 
-module.exports = async (_: any): Promise<void> => {
+module.exports = async (lilla: Lilla): Promise<void> => {
     const commands: string[] = [];
     let command_files: string[] = readdirSync("./src/commands");
 
@@ -10,19 +11,19 @@ module.exports = async (_: any): Promise<void> => {
     command_files.forEach((module: string) => {
         const command = require(`${__dirname}/${module}`);
         commands.push(command.data.toJSON());
-        _.commands[module] = command.callback;
+        lilla.commands.set(module, command.callback);
     });
 
-    const rest_client: REST = new REST().setToken(_.TOKEN);
+    const rest_client: REST = new REST().setToken(lilla.TOKEN);
 
     try {
         const data: any = await rest_client.put(
-            Routes.applicationGuildCommands(_.client.user.id, "1309275524652073080"),
+            Routes.applicationGuildCommands(lilla.client.user.id, "1309275524652073080"),
             { body: commands }
         );
 
         await rest_client.put(
-            Routes.applicationCommands(_.client.user.id),
+            Routes.applicationCommands(lilla.client.user.id),
             { body: commands }
         );
 

--- a/src/commands/revisions.ts
+++ b/src/commands/revisions.ts
@@ -1,4 +1,5 @@
 import { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, ChatInputCommandInteraction, TextChannel, MessageCollector, Message } from "discord.js";
+import { Lilla } from "../../types/lilla";
 
 const command: SlashCommandBuilder = new SlashCommandBuilder()
     .setName("revisions")
@@ -19,11 +20,11 @@ const buttons: ActionRowBuilder<ButtonBuilder> = new ActionRowBuilder<ButtonBuil
 
 module.exports = {
     data: command,
-    async callback(interaction: ChatInputCommandInteraction, _: any): Promise<void> {
-        const question_index = Math.floor(Math.random() * _.questions_emb.length);
-        const question: any = _.questions_emb[question_index];
+    async callback(interaction: ChatInputCommandInteraction, lilla: Lilla): Promise<void> {
+        const question_index = Math.floor(Math.random() * lilla.questions_emb.length);
+        const question: any = lilla.questions_emb[question_index];
 
-        const channel: TextChannel = await _.client.channels.fetch(interaction.channelId) as TextChannel;
+        const channel: TextChannel = await lilla.client.channels.fetch(interaction.channelId) as TextChannel;
         const collector: MessageCollector = channel.createMessageCollector(
             {
                 filter: (message: Message): boolean => { return message.author.id == interaction.user.id; },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { CacheType, Client, Events, Interaction } from "discord.js";
 import { config } from "dotenv";
+import { Lilla } from "../types/lilla";
 
 const load_commands = require("./commands/commands");
 const questions_emb = require("../questions/prog_emb.json");
@@ -15,25 +16,25 @@ const client: Client = new Client({
     intents: ["DirectMessages", "DirectMessageTyping", "GuildMembers", "GuildMessageTyping", "GuildMessages", "GuildModeration", "GuildPresences", "Guilds", "MessageContent"]
 });
 
-const _: any = {
+const lilla: Lilla = {
     client,
-    commands: [],
+    commands: new Map(),
     TOKEN: token,
     questions_emb: questions_emb.questions
 };
 
 client.on(Events.ClientReady, async () => {
 
-    await load_commands(_);
+    await load_commands(lilla);
 
     console.log("🗽 Lilla Cabot Perry up and running...");
 });
 
 client.on(Events.InteractionCreate, (interaction: Interaction<CacheType>): void => {
     if (!interaction.isChatInputCommand()) return;
-    if (!(interaction.commandName in _.commands)) return;
+    if (!lilla.commands.has(interaction.commandName)) return;
 
-    _.commands[interaction.commandName](interaction, _);
+    lilla.commands.get(interaction.commandName)(interaction, lilla);
 });
 
 try {

--- a/types/lilla.ts
+++ b/types/lilla.ts
@@ -1,0 +1,13 @@
+import { Client, ChatInputCommandInteraction } from "discord.js"
+
+export type LillaCommandCallback = (
+    interaction: ChatInputCommandInteraction,
+    self: Lilla,
+) => Promise<void>;
+
+export type Lilla = {
+    client: Client,
+    TOKEN: string,
+    questions_emb: {q: string, r: string}[],
+    commands: Map<string, LillaCommandCallback>,
+}


### PR DESCRIPTION
Hi Fabian

If there's no objection, I think you can close #1.
I changed the `_ ` to 'lilla', the any types from lilla to Lilla.

commands become `Map<string, LillaCommandCallback>`, not `array/json`.

